### PR TITLE
Chore add Rails 4 and Ruby 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   #- "1.9.2"
   - "1.9.3"
+  - "2.0.0"
   #- jruby-19mode # JRuby in 1.9 mode
   #- rbx-19mode
 before_script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    chilean_cities (0.0.1.alpha)
-      rails (~> 3.2.11)
+    chilean_cities (0.1.0)
+      rails (>= 3.2.11)
 
 GEM
   remote: https://rubygems.org/
@@ -34,7 +34,7 @@ GEM
     activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    arel (3.0.2)
+    arel (3.0.3)
     builder (3.0.4)
     capybara (2.0.2)
       mime-types (>= 1.16)
@@ -118,10 +118,10 @@ GEM
     sqlite3 (1.3.7)
     thor (0.17.0)
     tilt (1.3.3)
-    treetop (1.4.12)
+    treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.35)
+    tzinfo (0.3.38)
     websocket (1.0.7)
     xpath (1.0.0)
       nokogiri (~> 1.3)

--- a/app/models/chilean_cities/comuna.rb
+++ b/app/models/chilean_cities/comuna.rb
@@ -1,5 +1,21 @@
 module ChileanCities
   class Comuna < ActiveRecord::Base
-    attr_accessible :name, :code, :provincia, :region, :region_number
+
+    # See https://github.com/plataformatec/devise/blob/3232d14b20da4a596f2c0ff31b8a9ac0a529322e/lib/generators/devise/orm_helpers.rb
+    def self.needs_attr_accessible?
+      rails_3? && !strong_parameters_enabled?
+    end
+
+    def self.rails_3?
+      Rails::VERSION::MAJOR == 3
+    end
+
+    def self.strong_parameters_enabled?
+      defined?(ActionController::StrongParameters)
+    end
+
+    if needs_attr_accessible?
+      attr_accessible :name, :code, :provincia, :region, :region_number
+    end
   end
 end

--- a/chilean_cities.gemspec
+++ b/chilean_cities.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails", "~> 3.2.11"
+  gem.add_dependency "rails", ">= 3.2.11"
   gem.add_development_dependency "sqlite3"
 
   gem.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
**As** a developer 
**In order to** keep up-to-date 
**I want** `chilean_cities` to support Rails 4 and Ruby 2 
