### PR TITLE
Chore add rails 4 support fix

### DIFF
--- a/app/models/chilean_cities/comuna.rb
+++ b/app/models/chilean_cities/comuna.rb
@@ -19,7 +19,7 @@ module ChileanCities
     end
 
     if methods.exclude?(:find_or_create_by_name)
-      def find_or_create_by_name(attributes)
+      def self.find_or_create_by_name(attributes)
         find_or_create_by(attributes.fetch(:name)) do |comuna|
           comuna.assign_attributes(attributes.except(:name))
         end

--- a/app/models/chilean_cities/comuna.rb
+++ b/app/models/chilean_cities/comuna.rb
@@ -20,7 +20,7 @@ module ChileanCities
 
     if methods.exclude?(:find_or_create_by_name)
       def self.find_or_create_by_name(attributes)
-        find_or_create_by(attributes.fetch(:name)) do |comuna|
+        find_or_create_by(attributes.slice(:name)) do |comuna|
           comuna.assign_attributes(attributes.except(:name))
         end
       end

--- a/app/models/chilean_cities/comuna.rb
+++ b/app/models/chilean_cities/comuna.rb
@@ -17,5 +17,13 @@ module ChileanCities
     if needs_attr_accessible?
       attr_accessible :name, :code, :provincia, :region, :region_number
     end
+
+    if methods.exclude?(:find_or_create_by_name)
+      def find_or_create_by_name(attributes)
+        find_or_create_by(attributes.fetch(:name)) do |comuna|
+          comuna.assign_attributes(attributes.except(:name))
+        end
+      end
+    end
   end
 end

--- a/lib/chilean_cities/engine.rb
+++ b/lib/chilean_cities/engine.rb
@@ -9,5 +9,10 @@ module ChileanCities
       g.helper false
     end
 
+    config.to_prepare do
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |c|
+        require_dependency(c)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi, thanks for your job. I asked myself the pull request for add rails 4 support was not merged yet into master, so i just used the `chore-add-rails-4-support` branch in my project. I found that the seeds was not well generated for rails 4. The problem is that the seed file (seeds/comunas.rb) was using something like this:

```ruby
ChileanCities::Comuna.find_or_create_by_name(name: "Camarones", code: "15102", provincia: "Arica", region: "Arica y Parinacota", region_number: "XV")
```

In rails 4, `find_or_create_by_name` is not supported anymore, so the correct form for Rails 4 in actually something like this:

```ruby
ChileanCities::Comuna.find_or_create_by(name: "Camarones") { |comuna| comuna.assign_attributes(code: "15102", provincia: "Arica", region: "Arica y Parinacota", region_number: "XV") }
```

Because to change all the calls seems like a lot of work, it just reimplemented `find_or_create_by_name` when that method is not yet implemented (eg: Rails 4) using the new way.